### PR TITLE
Fix workflow to use upload-artifact@v2

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -46,7 +46,7 @@ jobs:
           cp repo-readiness-report.md $GITHUB_WORKSPACE/
       
       - name: Upload Report as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: repository-readiness-report
           path: repo-readiness-report.md


### PR DESCRIPTION
This PR fixes the workflow file to use upload-artifact@v2 instead of v3, which should resolve the "Missing download info for actions/upload-artifact@v3" error.